### PR TITLE
feat: HD wallet account management with atomic counter, batch create, and range read API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ vault-blockchain is a Vault plugin to generate and store Ethereum private keys. 
 
 It supports two modes:
 
-- **Wallet mode (HD)**: `wallets/:wallet_id/accounts/:index/...` — accounts derived from a BIP-39 mnemonic seed at path `m/44'/60'/0'/0/<index>`.
+- **Wallet mode (HD)**: `wallets/:wallet_id/...` — BIP-39 mnemonic seed; derived Ethereum accounts at `m/44'/60'/0'/0/<index>` using a per-wallet counter. Create one account per write on `.../accounts/`, up to **10000** per write on `.../accounts/batch`, **`LIST`** on `.../accounts/` lists stored indices, and **`GET .../accounts?start=N&end=M`** returns address metadata for an inclusive **`start`..`end`** range (max **10000** indices per call).
 - **Single-key account mode**: `accounts/:name/...` — one independently generated (or imported) key per logical name.
 
 ## Quick Start
@@ -76,7 +76,7 @@ path "blockchain/accounts/{{identity.entity.name}}/*" {
 
 ## API — Wallet Mode (HD)
 
-Accounts are derived from a BIP-39 mnemonic at `m/44'/60'/0'/0/<index>`. The mnemonic is stored in Vault and never returned.
+Accounts are derived from a BIP-39 mnemonic at `m/44'/60'/0'/0/<index>`. The mnemonic is stored in Vault and never returned. Indices are allocated in order by a **counter** (with per-wallet locking on each Vault active node). `LIST .../accounts/` returns **all** stored index keys (sorted only; no range filter). For a bounded inclusive range of **`start`..`end`** with **address** and **derivation_path** for each index, use **`GET .../accounts?start=N&end=M`** (see below). `LIST` is not a preview of unused counter slots.
 
 ### Wallets
 
@@ -91,6 +91,8 @@ Accounts are derived from a BIP-39 mnemonic at `m/44'/60'/0'/0/<index>`. The mne
 ##### `LIST blockchain/wallets/`
 
 No parameters.
+
+**Response:** Vault list payload with `keys` — sorted `wallet_id` strings that appear under the `wallets/` storage prefix (in normal operation these correspond to wallets created via `create` or `import`).
 
 ##### `POST blockchain/wallets/:wallet_id/create`
 
@@ -107,31 +109,63 @@ No parameters.
 
 ### Derived Accounts
 
+New accounts are assigned the next free **address index** from a per-wallet counter (serialized with a mutex on each Vault active node). Storage holds public metadata per index; the mnemonic is never returned.
+
 | Method | Path |
 | ------ | ---- |
-| `POST` | `blockchain/wallets/:wallet_id/accounts/:index` |
-| `GET`  | `blockchain/wallets/:wallet_id/accounts/:index` |
 | `LIST` | `blockchain/wallets/:wallet_id/accounts/` |
+| `POST` | `blockchain/wallets/:wallet_id/accounts/` — create **one** derived account at the next counter index (`Create` and `Update` are both wired for Vault HTTP routing). |
+| `POST` | `blockchain/wallets/:wallet_id/accounts/batch` — create **many** accounts in one request (see below). |
+| `GET`  | `blockchain/wallets/:wallet_id/accounts` — read metadata for every index in an inclusive **`start`..`end`** range (query params; see below). |
+| `GET`  | `blockchain/wallets/:wallet_id/accounts/:index` — read stored address and derivation path for a **decimal** non-negative index (`0..2147483647`). |
 
 #### Parameters
-
-##### `POST blockchain/wallets/:wallet_id/accounts/:index`
-
-* `wallet_id` `(string: <required>)` - Wallet identifier in the path.
-* `index` `(string: <required>)` - BIP-44 address index (non-negative integer; range `0..2147483647`).
-
-**Response:** `{ "address": "0x...", "account_index": "0", "derivation_path": "m/44'/60'/0'/0/0" }`
-
-##### `GET blockchain/wallets/:wallet_id/accounts/:index`
-
-* `wallet_id` `(string: <required>)` - Wallet identifier in the path.
-* `index` `(string: <required>)` - BIP-44 address index.
-
-**Response:** `{ "address": "0x...", "account_index": "0", "derivation_path": "m/44'/60'/0'/0/0" }`
 
 ##### `LIST blockchain/wallets/:wallet_id/accounts/`
 
 * `wallet_id` `(string: <required>)` - Wallet identifier in the path.
+
+**Response:** Vault list payload with `keys` — sorted decimal index strings for which a derived account record exists (not the counter “next index” itself). There is **no** `start`/`end` filtering on `LIST`; use **`GET .../accounts?start=N&end=M`** for a bounded index range with full metadata.
+
+##### `GET blockchain/wallets/:wallet_id/accounts`
+
+Range read — returns full metadata for every index in an inclusive `start`..`end` window. Use `vault read` or HTTP `GET` with query parameters.
+
+```bash
+vault read blockchain/wallets/alice/accounts start=2 end=5
+# curl equivalent:
+# curl -H "X-Vault-Token: $VAULT_TOKEN" \
+#   "$VAULT_ADDR/v1/blockchain/wallets/alice/accounts?start=2&end=5"
+```
+
+* `wallet_id` `(string: <required>)` - Wallet identifier in the path.
+* `start` `(string: <required>)` - Inclusive lower index (decimal non-negative; max `2147483647`).
+* `end` `(string: <required>)` - Inclusive upper index (same bounds). Must satisfy `start <= end`.
+* Span limit: **`end - start + 1` ≤ `10000`**. Every index in the range must already exist in storage; otherwise the plugin returns an error (no partial payload).
+
+**Response:** `{ "wallet_id": "...", "accounts": [ { "account_index": "...", "address": "0x...", "derivation_path": "..." }, ... ] }` — one element per index from `start` through `end`, in order.
+
+##### `POST blockchain/wallets/:wallet_id/accounts/`
+
+* `wallet_id` `(string: <required>)` - Wallet identifier in the path.
+
+**Response:** `{ "address": "0x...", "account_index": "0", "derivation_path": "m/44'/60'/0'/0/0" }`
+
+##### `POST blockchain/wallets/:wallet_id/accounts/batch`
+
+* `wallet_id` `(string: <required>)` - Wallet identifier in the path.
+* `count` `(string: <required>)` - Number of accounts to create in one call. Must be a positive integer **`1`..`10000`**. The plugin rejects the **entire** request up front if any index in the batch would exceed the BIP-44 address index maximum (`2147483647`), so you do not get a half-applied batch for that case.
+
+**Response:** `{ "wallet_id": "...", "accounts": [ { "account_index": "...", "address": "0x...", "derivation_path": "..." }, ... ] }`
+
+If the batch is rejected because it would exceed the BIP-44 index bound, **no** new accounts are written for that request. If a **storage** error occurs partway through an otherwise valid batch, accounts already persisted in that call remain (there is no multi-key transaction).
+
+##### `GET blockchain/wallets/:wallet_id/accounts/:index`
+
+* `wallet_id` `(string: <required>)` - Wallet identifier in the path.
+* `index` `(string: <required>)` - BIP-44 address index in the path (decimal `0..2147483647`).
+
+**Response:** `{ "address": "0x...", "account_index": "0", "derivation_path": "m/44'/60'/0'/0/0" }`
 
 ### Wallet Sign Transaction
 

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -18,6 +18,8 @@
 package backend
 
 import (
+	"sync"
+
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
 
@@ -28,16 +30,19 @@ import (
 // ethereumBackend is the Vault logical backend for Ethereum wallet and single-key operations.
 type ethereumBackend struct {
 	*framework.Backend
+	// walletMu provides per-wallet mutex locks for operations that require atomicity
+	// within a single Vault active node (counter read-increment-write).
+	walletMu sync.Map
 }
 
-// newBackend constructs the backend with paths, seal-wrap prefixes, and mutexes for handlers.
+// newBackend constructs the backend with paths and seal-wrap prefixes.
 func newBackend(conf *logical.BackendConfig) (*ethereumBackend, error) {
 	var b ethereumBackend
 	b.Backend = &framework.Backend{
 		Help:           "",
 		RunningVersion: "v" + version.Version,
 		Paths: framework.PathAppend(
-			path.GetPaths(),
+			path.GetPaths(&b.walletMu),
 		),
 		PathsSpecial: &logical.Paths{
 			SealWrapStorage: []string{

--- a/internal/model/wallet.go
+++ b/internal/model/wallet.go
@@ -35,6 +35,11 @@ type WalletSeed struct {
 	Mnemonic string `json:"mnemonic"`
 }
 
+// WalletCounter tracks the next auto-increment index for derived accounts; stored at wallets/<wallet_id>/counter.
+type WalletCounter struct {
+	NextIndex uint32 `json:"next_index"`
+}
+
 // DerivedAccount holds public metadata for a derived address; stored at wallets/<wallet_id>/accounts/<index>.
 type DerivedAccount struct {
 	Address        string `json:"address"`

--- a/internal/path/factory.go
+++ b/internal/path/factory.go
@@ -18,6 +18,8 @@
 package path
 
 import (
+	"sync"
+
 	"github.com/hashicorp/vault/sdk/framework"
 
 	"github.com/bsostech/vault-blockchain/internal/path/account"
@@ -25,9 +27,9 @@ import (
 )
 
 // GetPaths returns all framework paths.
-func GetPaths() []*framework.Path {
+func GetPaths(walletMu *sync.Map) []*framework.Path {
 	acctPaths := account.Paths()
-	walletPaths := wallet.Paths()
+	walletPaths := wallet.Paths(walletMu)
 	out := make([]*framework.Path, 0, len(acctPaths)+len(walletPaths))
 	out = append(out, acctPaths...)
 	out = append(out, walletPaths...)

--- a/internal/path/factory_test.go
+++ b/internal/path/factory_test.go
@@ -18,6 +18,7 @@
 package path_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -31,12 +32,13 @@ import (
 func TestGetPaths(t *testing.T) {
 	t.Parallel()
 
-	got := path.GetPaths()
+	var walletMu sync.Map
+	got := path.GetPaths(&walletMu)
 	if len(got) == 0 {
 		t.Fatal("expected non-empty paths.")
 	}
 
-	wantLen := len(account.Paths()) + len(wallet.Paths())
+	wantLen := len(account.Paths()) + len(wallet.Paths(&walletMu))
 	if len(got) != wantLen {
 		t.Fatalf("len(got)=%d want %d.", len(got), wantLen)
 	}

--- a/internal/path/storagekey/storagekey.go
+++ b/internal/path/storagekey/storagekey.go
@@ -44,3 +44,8 @@ func AccountKey(walletID, index string) string {
 func AccountsListPrefix(walletID string) string {
 	return fmt.Sprintf("wallets/%s/accounts/", walletID)
 }
+
+// CounterKey returns the storage path for a wallet's auto-increment account counter.
+func CounterKey(walletID string) string {
+	return fmt.Sprintf("wallets/%s/counter", walletID)
+}

--- a/internal/path/wallet/crud.go
+++ b/internal/path/wallet/crud.go
@@ -163,47 +163,12 @@ func handleListWallets(ctx context.Context, req *logical.Request, _ *framework.F
 	return logical.ListResponse(ids), nil
 }
 
-// handleDerivedAccountUpdateConflict rejects updates with HTTP 409 because derived rows are immutable.
-func handleDerivedAccountUpdateConflict(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	_ = ctx
-	_ = data
-	return logical.RespondWithStatusCode(
-		logical.ErrorResponse("account index already exists"),
-		req,
-		http.StatusConflict,
-	)
-}
-
-// handleDerivedAccountCreate derives m/44'/60'/0'/0/<index> and persists address metadata for the wallet.
+// handleDerivedAccountCreate derives m/44'/60'/0'/0/<counter> and persists address metadata for the wallet.
+// The index is assigned automatically using a per-wallet counter; callers do not specify it.
 func handleDerivedAccountCreate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	walletID, err := model.NewFieldDataWrapper(data).MustGetString("wallet_id")
 	if err != nil || walletID == "" {
 		return logical.ErrorResponse("wallet_id is required"), nil
-	}
-	indexStr, err := model.NewFieldDataWrapper(data).MustGetString("index")
-	if err != nil || indexStr == "" {
-		return logical.ErrorResponse("index is required"), nil
-	}
-
-	indexVal, err := ParseAddressIndex(indexStr)
-	if err != nil {
-		switch {
-		case errors.Is(err, ErrInvalidPathIndexFormat), errors.Is(err, ErrInvalidPathIndexRange):
-			return logical.ErrorResponse("%s", err.Error()), nil
-		default:
-			return nil, err
-		}
-	}
-
-	acctKey := storagekey.AccountKey(walletID, indexStr)
-	if existing, err := req.Storage.Get(ctx, acctKey); err != nil {
-		return nil, fmt.Errorf("get derived account %s/%s: %w", walletID, indexStr, err)
-	} else if existing != nil {
-		return logical.RespondWithStatusCode(
-			logical.ErrorResponse("account index already exists"),
-			req,
-			http.StatusConflict,
-		)
 	}
 
 	seed, err := ReadWalletSeed(ctx, req.Storage, walletID)
@@ -214,24 +179,33 @@ func handleDerivedAccountCreate(ctx context.Context, req *logical.Request, data 
 		return logical.ErrorResponse("wallet not found"), nil
 	}
 
-	address, derivationPath, err := model.DeriveEthereumAccount(seed.Mnemonic, indexVal)
+	nextIndex, err := ReadWalletCounter(ctx, req.Storage, walletID)
 	if err != nil {
-		if errors.Is(err, model.ErrIndexOutOfRange) {
-			return logical.ErrorResponse("index must be 0..2147483647"), nil
-		}
-		return nil, fmt.Errorf("derive account %s/%d: %w", walletID, indexVal, err)
+		return nil, err
+	}
+	if err := model.ValidateAddressIndex(uint64(nextIndex)); err != nil {
+		return logical.ErrorResponse("account index limit reached (max 2147483647)"), nil
 	}
 
+	address, derivationPath, err := model.DeriveEthereumAccount(seed.Mnemonic, nextIndex)
+	if err != nil {
+		return nil, fmt.Errorf("derive account %s/%d: %w", walletID, nextIndex, err)
+	}
+
+	indexStr := fmt.Sprintf("%d", nextIndex)
 	derived := &model.DerivedAccount{
 		Address:        address,
 		DerivationPath: derivationPath,
 	}
-	entry, err := logical.StorageEntryJSON(acctKey, derived)
+	entry, err := logical.StorageEntryJSON(storagekey.AccountKey(walletID, indexStr), derived)
 	if err != nil {
-		return nil, fmt.Errorf("encode derived account %s: %w", acctKey, err)
+		return nil, fmt.Errorf("encode derived account %s/%s: %w", walletID, indexStr, err)
 	}
 	if err := req.Storage.Put(ctx, entry); err != nil {
-		return nil, fmt.Errorf("put derived account %s: %w", acctKey, err)
+		return nil, fmt.Errorf("put derived account %s/%s: %w", walletID, indexStr, err)
+	}
+	if err := WriteWalletCounter(ctx, req.Storage, walletID, nextIndex+1); err != nil {
+		return nil, err
 	}
 
 	return &logical.Response{
@@ -277,6 +251,7 @@ func handleDerivedAccountRead(ctx context.Context, req *logical.Request, data *f
 }
 
 // handleListDerivedAccounts returns sorted index strings for derived accounts that exist in storage.
+// Optional start and end query parameters (inclusive) filter the returned indices to a range.
 func handleListDerivedAccounts(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	walletID, err := model.NewFieldDataWrapper(data).MustGetString("wallet_id")
 	if err != nil || walletID == "" {
@@ -285,6 +260,29 @@ func handleListDerivedAccounts(ctx context.Context, req *logical.Request, data *
 	children, err := req.Storage.List(ctx, storagekey.AccountsListPrefix(walletID))
 	if err != nil {
 		return nil, fmt.Errorf("list derived accounts %s: %w", walletID, err)
+	}
+
+	startStr := model.NewFieldDataWrapper(data).GetString("start", "")
+	endStr := model.NewFieldDataWrapper(data).GetString("end", "")
+
+	hasStart := startStr != ""
+	hasEnd := endStr != ""
+
+	var startVal, endVal int
+	if hasStart {
+		startVal, err = strconv.Atoi(startStr)
+		if err != nil || startVal < 0 {
+			return logical.ErrorResponse("start must be a non-negative integer"), nil
+		}
+	}
+	if hasEnd {
+		endVal, err = strconv.Atoi(endStr)
+		if err != nil || endVal < 0 {
+			return logical.ErrorResponse("end must be a non-negative integer"), nil
+		}
+	}
+	if hasStart && hasEnd && startVal > endVal {
+		return logical.ErrorResponse("start must be <= end"), nil
 	}
 
 	indices := make([]int, 0, len(children))
@@ -297,13 +295,19 @@ func handleListDerivedAccounts(ctx context.Context, req *logical.Request, data *
 		if err != nil {
 			continue
 		}
+		if hasStart && idxInt < startVal {
+			continue
+		}
+		if hasEnd && idxInt > endVal {
+			continue
+		}
 		indices = append(indices, idxInt)
 	}
 	sort.Ints(indices)
 
-	var keys []string
-	for _, idx := range indices {
-		keys = append(keys, fmt.Sprintf("%d", idx))
+	keys := make([]string, len(indices))
+	for i, idx := range indices {
+		keys[i] = fmt.Sprintf("%d", idx)
 	}
 	return logical.ListResponse(keys), nil
 }

--- a/internal/path/wallet/crud.go
+++ b/internal/path/wallet/crud.go
@@ -44,6 +44,9 @@ var errAccountIndexLimitReached = errors.New("account index limit reached")
 // maxBatchDerivedAccounts caps how many derived accounts one batch request may create.
 const maxBatchDerivedAccounts = 10000
 
+// maxBulkReadDerivedSpan is the maximum inclusive range size (end - start + 1) for bulk metadata read.
+const maxBulkReadDerivedSpan = 10000
+
 // putWalletSeedIfAbsent writes the BIP-39 seed JSON under wallets/<id>/seed if absent.
 func putWalletSeedIfAbsent(
 	ctx context.Context,
@@ -313,6 +316,89 @@ func makeHandleBatchDerivedAccountCreate(walletMu *sync.Map) framework.Operation
 	}
 }
 
+// parseInclusiveIndexRange validates start/end query parameters from FieldData (Method A: both required).
+// Returns (start, end, nil, nil) on valid input; (0, 0, errResp, nil) on logical validation error;
+// (0, 0, nil, err) is never returned but kept for signature consistency with handler conventions.
+func parseInclusiveIndexRange(data *framework.FieldData) (start, end int, errResp *logical.Response, err error) {
+	wrapper := model.NewFieldDataWrapper(data)
+	startStr, e := wrapper.MustGetString("start")
+	if e != nil || startStr == "" {
+		return 0, 0, logical.ErrorResponse("start is required"), nil
+	}
+	endStr, e := wrapper.MustGetString("end")
+	if e != nil || endStr == "" {
+		return 0, 0, logical.ErrorResponse("end is required"), nil
+	}
+
+	startVal, e := strconv.Atoi(startStr)
+	if e != nil || startVal < 0 {
+		return 0, 0, logical.ErrorResponse("start must be a non-negative integer"), nil
+	}
+	if uint64(startVal) > uint64(model.MaxBIP44AddressIndex) {
+		return 0, 0, logical.ErrorResponse("start must be <= 2147483647"), nil
+	}
+	endVal, e := strconv.Atoi(endStr)
+	if e != nil || endVal < 0 {
+		return 0, 0, logical.ErrorResponse("end must be a non-negative integer"), nil
+	}
+	if uint64(endVal) > uint64(model.MaxBIP44AddressIndex) {
+		return 0, 0, logical.ErrorResponse("end must be <= 2147483647"), nil
+	}
+	if startVal > endVal {
+		return 0, 0, logical.ErrorResponse("start must be <= end"), nil
+	}
+	span := uint64(endVal) - uint64(startVal) + 1
+	if span > maxBulkReadDerivedSpan {
+		return 0, 0, logical.ErrorResponse("range must include at most %d indices (end - start + 1)", maxBulkReadDerivedSpan), nil
+	}
+	return startVal, endVal, nil, nil
+}
+
+// handleReadDerivedAccountsRange returns address and derivation_path for each index in [start, end].
+// Both start and end are required query parameters. Every index in the range must exist in storage;
+// span (end - start + 1) must be <= maxBulkReadDerivedSpan.
+func handleReadDerivedAccountsRange(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+	walletID, err := model.NewFieldDataWrapper(data).MustGetString("wallet_id")
+	if err != nil || walletID == "" {
+		return logical.ErrorResponse("wallet_id is required"), nil
+	}
+	startVal, endVal, errResp, err := parseInclusiveIndexRange(data)
+	if err != nil {
+		return nil, err
+	}
+	if errResp != nil {
+		return errResp, nil
+	}
+
+	accounts := make([]interface{}, 0, endVal-startVal+1)
+	for idx := startVal; idx <= endVal; idx++ {
+		indexStr := strconv.Itoa(idx)
+		entry, err := req.Storage.Get(ctx, storagekey.AccountKey(walletID, indexStr))
+		if err != nil {
+			return nil, fmt.Errorf("get derived account %s/%s: %w", walletID, indexStr, err)
+		}
+		if entry == nil {
+			return logical.ErrorResponse("derived account not found at index %s", indexStr), nil
+		}
+		var derived model.DerivedAccount
+		if err := entry.DecodeJSON(&derived); err != nil {
+			return nil, fmt.Errorf("decode derived account %s/%s: %w", walletID, indexStr, err)
+		}
+		accounts = append(accounts, map[string]interface{}{
+			"account_index":   indexStr,
+			"address":         derived.Address,
+			"derivation_path": derived.DerivationPath,
+		})
+	}
+
+	return &logical.Response{
+		Data: map[string]interface{}{
+			"wallet_id": walletID,
+			"accounts":  accounts,
+		},
+	}, nil
+}
+
 // handleDerivedAccountRead returns stored address and derivation path for wallet_id and index.
 func handleDerivedAccountRead(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	walletID, err := model.NewFieldDataWrapper(data).MustGetString("wallet_id")
@@ -347,7 +433,6 @@ func handleDerivedAccountRead(ctx context.Context, req *logical.Request, data *f
 }
 
 // handleListDerivedAccounts returns sorted index strings for derived accounts that exist in storage.
-// Optional start and end query parameters (inclusive) filter the returned indices to a range.
 func handleListDerivedAccounts(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
 	walletID, err := model.NewFieldDataWrapper(data).MustGetString("wallet_id")
 	if err != nil || walletID == "" {
@@ -358,35 +443,6 @@ func handleListDerivedAccounts(ctx context.Context, req *logical.Request, data *
 		return nil, fmt.Errorf("list derived accounts %s: %w", walletID, err)
 	}
 
-	startStr := model.NewFieldDataWrapper(data).GetString("start", "")
-	endStr := model.NewFieldDataWrapper(data).GetString("end", "")
-
-	hasStart := startStr != ""
-	hasEnd := endStr != ""
-
-	var startVal, endVal int
-	if hasStart {
-		startVal, err = strconv.Atoi(startStr)
-		if err != nil || startVal < 0 {
-			return logical.ErrorResponse("start must be a non-negative integer"), nil
-		}
-		if uint64(startVal) > uint64(model.MaxBIP44AddressIndex) {
-			return logical.ErrorResponse("start must be <= 2147483647"), nil
-		}
-	}
-	if hasEnd {
-		endVal, err = strconv.Atoi(endStr)
-		if err != nil || endVal < 0 {
-			return logical.ErrorResponse("end must be a non-negative integer"), nil
-		}
-		if uint64(endVal) > uint64(model.MaxBIP44AddressIndex) {
-			return logical.ErrorResponse("end must be <= 2147483647"), nil
-		}
-	}
-	if hasStart && hasEnd && startVal > endVal {
-		return logical.ErrorResponse("start must be <= end"), nil
-	}
-
 	indices := make([]int, 0, len(children))
 	for _, child := range children {
 		idxStr := strings.TrimSuffix(child, "/")
@@ -395,12 +451,6 @@ func handleListDerivedAccounts(ctx context.Context, req *logical.Request, data *
 		}
 		idxInt, err := strconv.Atoi(idxStr)
 		if err != nil {
-			continue
-		}
-		if hasStart && idxInt < startVal {
-			continue
-		}
-		if hasEnd && idxInt > endVal {
 			continue
 		}
 		indices = append(indices, idxInt)

--- a/internal/path/wallet/crud.go
+++ b/internal/path/wallet/crud.go
@@ -38,6 +38,12 @@ import (
 // errWalletAlreadyExists indicates a seed is already stored for wallet_id.
 var errWalletAlreadyExists = errors.New("wallet_id already exists")
 
+// errAccountIndexLimitReached indicates the next derived index would exceed BIP-44 bounds.
+var errAccountIndexLimitReached = errors.New("account index limit reached")
+
+// maxBatchDerivedAccounts caps how many derived accounts one batch request may create.
+const maxBatchDerivedAccounts = 10000
+
 // putWalletSeedIfAbsent writes the BIP-39 seed JSON under wallets/<id>/seed if absent.
 func putWalletSeedIfAbsent(
 	ctx context.Context,
@@ -164,6 +170,40 @@ func handleListWallets(ctx context.Context, req *logical.Request, _ *framework.F
 	return logical.ListResponse(ids), nil
 }
 
+// createNextDerivedAccount allocates the current counter index, persists derived metadata, and advances the counter.
+// Caller must hold the per-wallet mutex from walletMu and ensure the wallet seed exists.
+func createNextDerivedAccount(ctx context.Context, req *logical.Request, walletID, mnemonic string) (indexStr, address, derivationPath string, err error) {
+	nextIndex, err := ReadWalletCounter(ctx, req.Storage, walletID)
+	if err != nil {
+		return "", "", "", err
+	}
+	if err := model.ValidateAddressIndex(uint64(nextIndex)); err != nil {
+		return "", "", "", errAccountIndexLimitReached
+	}
+
+	address, derivationPath, err = model.DeriveEthereumAccount(mnemonic, nextIndex)
+	if err != nil {
+		return "", "", "", fmt.Errorf("derive account %s/%d: %w", walletID, nextIndex, err)
+	}
+
+	indexStr = fmt.Sprintf("%d", nextIndex)
+	derived := &model.DerivedAccount{
+		Address:        address,
+		DerivationPath: derivationPath,
+	}
+	entry, err := logical.StorageEntryJSON(storagekey.AccountKey(walletID, indexStr), derived)
+	if err != nil {
+		return "", "", "", fmt.Errorf("encode derived account %s/%s: %w", walletID, indexStr, err)
+	}
+	if err := req.Storage.Put(ctx, entry); err != nil {
+		return "", "", "", fmt.Errorf("put derived account %s/%s: %w", walletID, indexStr, err)
+	}
+	if err := WriteWalletCounter(ctx, req.Storage, walletID, nextIndex+1); err != nil {
+		return "", "", "", err
+	}
+	return indexStr, address, derivationPath, nil
+}
+
 // makeHandleDerivedAccountCreate returns a handler that derives m/44'/60'/0'/0/<counter> and
 // persists address metadata for the wallet. The index is assigned automatically using a
 // per-wallet counter. walletMu serialises the counter read-increment-write sequence so that
@@ -187,32 +227,11 @@ func makeHandleDerivedAccountCreate(walletMu *sync.Map) framework.OperationFunc 
 			return logical.ErrorResponse("wallet not found"), nil
 		}
 
-		nextIndex, err := ReadWalletCounter(ctx, req.Storage, walletID)
+		indexStr, address, derivationPath, err := createNextDerivedAccount(ctx, req, walletID, seed.Mnemonic)
 		if err != nil {
-			return nil, err
-		}
-		if err := model.ValidateAddressIndex(uint64(nextIndex)); err != nil {
-			return logical.ErrorResponse("account index limit reached (max 2147483647)"), nil
-		}
-
-		address, derivationPath, err := model.DeriveEthereumAccount(seed.Mnemonic, nextIndex)
-		if err != nil {
-			return nil, fmt.Errorf("derive account %s/%d: %w", walletID, nextIndex, err)
-		}
-
-		indexStr := fmt.Sprintf("%d", nextIndex)
-		derived := &model.DerivedAccount{
-			Address:        address,
-			DerivationPath: derivationPath,
-		}
-		entry, err := logical.StorageEntryJSON(storagekey.AccountKey(walletID, indexStr), derived)
-		if err != nil {
-			return nil, fmt.Errorf("encode derived account %s/%s: %w", walletID, indexStr, err)
-		}
-		if err := req.Storage.Put(ctx, entry); err != nil {
-			return nil, fmt.Errorf("put derived account %s/%s: %w", walletID, indexStr, err)
-		}
-		if err := WriteWalletCounter(ctx, req.Storage, walletID, nextIndex+1); err != nil {
+			if errors.Is(err, errAccountIndexLimitReached) {
+				return logical.ErrorResponse("account index limit reached (max 2147483647)"), nil
+			}
 			return nil, err
 		}
 
@@ -221,6 +240,74 @@ func makeHandleDerivedAccountCreate(walletMu *sync.Map) framework.OperationFunc 
 				"address":         address,
 				"account_index":   indexStr,
 				"derivation_path": derivationPath,
+			},
+		}, nil
+	}
+}
+
+// makeHandleBatchDerivedAccountCreate returns a handler that creates up to maxBatchDerivedAccounts
+// derived accounts in one request, holding the same per-wallet mutex for the whole loop.
+func makeHandleBatchDerivedAccountCreate(walletMu *sync.Map) framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		wrapper := model.NewFieldDataWrapper(data)
+		walletID, err := wrapper.MustGetString("wallet_id")
+		if err != nil || walletID == "" {
+			return logical.ErrorResponse("wallet_id is required"), nil
+		}
+		countStr, err := wrapper.MustGetString("count")
+		if err != nil || countStr == "" {
+			return logical.ErrorResponse("count is required"), nil
+		}
+		count, err := strconv.Atoi(countStr)
+		if err != nil || count < 1 {
+			return logical.ErrorResponse("count must be a positive integer"), nil
+		}
+		if count > maxBatchDerivedAccounts {
+			return logical.ErrorResponse("count must be <= %d", maxBatchDerivedAccounts), nil
+		}
+
+		mu, _ := walletMu.LoadOrStore(walletID, &sync.Mutex{})
+		mu.(*sync.Mutex).Lock()
+		defer mu.(*sync.Mutex).Unlock()
+
+		seed, err := ReadWalletSeed(ctx, req.Storage, walletID)
+		if err != nil {
+			return nil, err
+		}
+		if seed == nil || seed.Mnemonic == "" {
+			return logical.ErrorResponse("wallet not found"), nil
+		}
+
+		nextStart, err := ReadWalletCounter(ctx, req.Storage, walletID)
+		if err != nil {
+			return nil, err
+		}
+		// Reject the whole batch if any index would exceed BIP-44 address_index max (avoids partial creates).
+		lastIndex := uint64(nextStart) + uint64(count) - 1
+		if lastIndex > uint64(model.MaxBIP44AddressIndex) {
+			return logical.ErrorResponse("account index limit reached (max 2147483647)"), nil
+		}
+
+		accounts := make([]interface{}, 0, count)
+		for i := 0; i < count; i++ {
+			indexStr, address, derivationPath, err := createNextDerivedAccount(ctx, req, walletID, seed.Mnemonic)
+			if err != nil {
+				if errors.Is(err, errAccountIndexLimitReached) {
+					return logical.ErrorResponse("account index limit reached (max 2147483647)"), nil
+				}
+				return nil, err
+			}
+			accounts = append(accounts, map[string]interface{}{
+				"account_index":   indexStr,
+				"address":         address,
+				"derivation_path": derivationPath,
+			})
+		}
+
+		return &logical.Response{
+			Data: map[string]interface{}{
+				"wallet_id": walletID,
+				"accounts":  accounts,
 			},
 		}, nil
 	}

--- a/internal/path/wallet/crud.go
+++ b/internal/path/wallet/crud.go
@@ -283,11 +283,17 @@ func handleListDerivedAccounts(ctx context.Context, req *logical.Request, data *
 		if err != nil || startVal < 0 {
 			return logical.ErrorResponse("start must be a non-negative integer"), nil
 		}
+		if uint64(startVal) > uint64(model.MaxBIP44AddressIndex) {
+			return logical.ErrorResponse("start must be <= 2147483647"), nil
+		}
 	}
 	if hasEnd {
 		endVal, err = strconv.Atoi(endStr)
 		if err != nil || endVal < 0 {
 			return logical.ErrorResponse("end must be a non-negative integer"), nil
+		}
+		if uint64(endVal) > uint64(model.MaxBIP44AddressIndex) {
+			return logical.ErrorResponse("end must be <= 2147483647"), nil
 		}
 	}
 	if hasStart && hasEnd && startVal > endVal {

--- a/internal/path/wallet/crud.go
+++ b/internal/path/wallet/crud.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/vault/sdk/framework"
 	"github.com/hashicorp/vault/sdk/logical"
@@ -163,58 +164,66 @@ func handleListWallets(ctx context.Context, req *logical.Request, _ *framework.F
 	return logical.ListResponse(ids), nil
 }
 
-// handleDerivedAccountCreate derives m/44'/60'/0'/0/<counter> and persists address metadata for the wallet.
-// The index is assigned automatically using a per-wallet counter; callers do not specify it.
-func handleDerivedAccountCreate(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
-	walletID, err := model.NewFieldDataWrapper(data).MustGetString("wallet_id")
-	if err != nil || walletID == "" {
-		return logical.ErrorResponse("wallet_id is required"), nil
-	}
+// makeHandleDerivedAccountCreate returns a handler that derives m/44'/60'/0'/0/<counter> and
+// persists address metadata for the wallet. The index is assigned automatically using a
+// per-wallet counter. walletMu serialises the counter read-increment-write sequence so that
+// concurrent requests to the same wallet_id cannot derive the same address.
+func makeHandleDerivedAccountCreate(walletMu *sync.Map) framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (*logical.Response, error) {
+		walletID, err := model.NewFieldDataWrapper(data).MustGetString("wallet_id")
+		if err != nil || walletID == "" {
+			return logical.ErrorResponse("wallet_id is required"), nil
+		}
 
-	seed, err := ReadWalletSeed(ctx, req.Storage, walletID)
-	if err != nil {
-		return nil, err
-	}
-	if seed == nil || seed.Mnemonic == "" {
-		return logical.ErrorResponse("wallet not found"), nil
-	}
+		mu, _ := walletMu.LoadOrStore(walletID, &sync.Mutex{})
+		mu.(*sync.Mutex).Lock()
+		defer mu.(*sync.Mutex).Unlock()
 
-	nextIndex, err := ReadWalletCounter(ctx, req.Storage, walletID)
-	if err != nil {
-		return nil, err
-	}
-	if err := model.ValidateAddressIndex(uint64(nextIndex)); err != nil {
-		return logical.ErrorResponse("account index limit reached (max 2147483647)"), nil
-	}
+		seed, err := ReadWalletSeed(ctx, req.Storage, walletID)
+		if err != nil {
+			return nil, err
+		}
+		if seed == nil || seed.Mnemonic == "" {
+			return logical.ErrorResponse("wallet not found"), nil
+		}
 
-	address, derivationPath, err := model.DeriveEthereumAccount(seed.Mnemonic, nextIndex)
-	if err != nil {
-		return nil, fmt.Errorf("derive account %s/%d: %w", walletID, nextIndex, err)
-	}
+		nextIndex, err := ReadWalletCounter(ctx, req.Storage, walletID)
+		if err != nil {
+			return nil, err
+		}
+		if err := model.ValidateAddressIndex(uint64(nextIndex)); err != nil {
+			return logical.ErrorResponse("account index limit reached (max 2147483647)"), nil
+		}
 
-	indexStr := fmt.Sprintf("%d", nextIndex)
-	derived := &model.DerivedAccount{
-		Address:        address,
-		DerivationPath: derivationPath,
-	}
-	entry, err := logical.StorageEntryJSON(storagekey.AccountKey(walletID, indexStr), derived)
-	if err != nil {
-		return nil, fmt.Errorf("encode derived account %s/%s: %w", walletID, indexStr, err)
-	}
-	if err := req.Storage.Put(ctx, entry); err != nil {
-		return nil, fmt.Errorf("put derived account %s/%s: %w", walletID, indexStr, err)
-	}
-	if err := WriteWalletCounter(ctx, req.Storage, walletID, nextIndex+1); err != nil {
-		return nil, err
-	}
+		address, derivationPath, err := model.DeriveEthereumAccount(seed.Mnemonic, nextIndex)
+		if err != nil {
+			return nil, fmt.Errorf("derive account %s/%d: %w", walletID, nextIndex, err)
+		}
 
-	return &logical.Response{
-		Data: map[string]interface{}{
-			"address":         address,
-			"account_index":   indexStr,
-			"derivation_path": derivationPath,
-		},
-	}, nil
+		indexStr := fmt.Sprintf("%d", nextIndex)
+		derived := &model.DerivedAccount{
+			Address:        address,
+			DerivationPath: derivationPath,
+		}
+		entry, err := logical.StorageEntryJSON(storagekey.AccountKey(walletID, indexStr), derived)
+		if err != nil {
+			return nil, fmt.Errorf("encode derived account %s/%s: %w", walletID, indexStr, err)
+		}
+		if err := req.Storage.Put(ctx, entry); err != nil {
+			return nil, fmt.Errorf("put derived account %s/%s: %w", walletID, indexStr, err)
+		}
+		if err := WriteWalletCounter(ctx, req.Storage, walletID, nextIndex+1); err != nil {
+			return nil, err
+		}
+
+		return &logical.Response{
+			Data: map[string]interface{}{
+				"address":         address,
+				"account_index":   indexStr,
+				"derivation_path": derivationPath,
+			},
+		}, nil
+	}
 }
 
 // handleDerivedAccountRead returns stored address and derivation path for wallet_id and index.

--- a/internal/path/wallet/crud_test.go
+++ b/internal/path/wallet/crud_test.go
@@ -20,6 +20,7 @@ package wallet
 import (
 	"context"
 	"net/http"
+	"sync"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -554,8 +555,11 @@ func TestHandleDerivedAccountCreate_autoIncrement(t *testing.T) {
 	mustPutWalletSeed(ctx, t, s, "wauto", testMnemonic)
 	req := &logical.Request{Storage: s}
 
+	var walletMu sync.Map
+	handler := makeHandleDerivedAccountCreate(&walletMu)
+
 	// First create → index 0.
-	resp, err := handleDerivedAccountCreate(ctx, req, walletFieldData(map[string]interface{}{
+	resp, err := handler(ctx, req, walletFieldData(map[string]interface{}{
 		"wallet_id": "wauto",
 	}))
 	if err != nil {
@@ -569,7 +573,7 @@ func TestHandleDerivedAccountCreate_autoIncrement(t *testing.T) {
 	}
 
 	// Second create → index 1.
-	resp2, err := handleDerivedAccountCreate(ctx, req, walletFieldData(map[string]interface{}{
+	resp2, err := handler(ctx, req, walletFieldData(map[string]interface{}{
 		"wallet_id": "wauto",
 	}))
 	if err != nil {
@@ -591,7 +595,10 @@ func TestHandleDerivedAccountCreate_missingWalletReturnsLogicalError(t *testing.
 	s := new(logical.InmemStorage)
 	req := &logical.Request{Storage: s}
 
-	resp, err := handleDerivedAccountCreate(ctx, req, walletFieldData(map[string]interface{}{
+	var walletMu sync.Map
+	handler := makeHandleDerivedAccountCreate(&walletMu)
+
+	resp, err := handler(ctx, req, walletFieldData(map[string]interface{}{
 		"wallet_id": "nonexistent",
 	}))
 	if err != nil {

--- a/internal/path/wallet/crud_test.go
+++ b/internal/path/wallet/crud_test.go
@@ -42,6 +42,8 @@ func walletFieldData(raw map[string]interface{}) *framework.FieldData {
 	baseKeys := []string{
 		"wallet_id",
 		"index",
+		"start",
+		"end",
 		"data",
 		"to",
 		"address_to",
@@ -542,3 +544,136 @@ func TestHandleListWallets_sorted(t *testing.T) {
 		t.Fatalf("keys=%v want [a b].", keys)
 	}
 }
+
+// TestHandleDerivedAccountCreate_autoIncrement verifies successive creates assign index 0, 1.
+func TestHandleDerivedAccountCreate_autoIncrement(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wauto", testMnemonic)
+	req := &logical.Request{Storage: s}
+
+	// First create → index 0.
+	resp, err := handleDerivedAccountCreate(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wauto",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.IsError() {
+		t.Fatalf("unexpected error response: %v", resp)
+	}
+	if got := resp.Data["account_index"]; got != "0" {
+		t.Fatalf("account_index=%v want 0.", got)
+	}
+
+	// Second create → index 1.
+	resp2, err := handleDerivedAccountCreate(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wauto",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp2 == nil || resp2.IsError() {
+		t.Fatalf("unexpected error response: %v", resp2)
+	}
+	if got := resp2.Data["account_index"]; got != "1" {
+		t.Fatalf("account_index=%v want 1.", got)
+	}
+}
+
+// TestHandleDerivedAccountCreate_missingWalletReturnsLogicalError verifies missing wallet returns an error response.
+func TestHandleDerivedAccountCreate_missingWalletReturnsLogicalError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	req := &logical.Request{Storage: s}
+
+	resp, err := handleDerivedAccountCreate(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "nonexistent",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatal("expected error response for missing wallet.")
+	}
+}
+
+// TestHandleListDerivedAccounts_noRange verifies all stored indices are returned when no range is given.
+func TestHandleListDerivedAccounts_noRange(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wlist", testMnemonic)
+	mustPutDerivedAccount(ctx, t, s, "wlist", "0", testMnemonic)
+	mustPutDerivedAccount(ctx, t, s, "wlist", "2", testMnemonic)
+	mustPutDerivedAccount(ctx, t, s, "wlist", "5", testMnemonic)
+	req := &logical.Request{Storage: s}
+
+	resp, err := handleListDerivedAccounts(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wlist",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, _ := resp.Data["keys"].([]string)
+	if len(keys) != 3 || keys[0] != "0" || keys[1] != "2" || keys[2] != "5" {
+		t.Fatalf("keys=%v want [0 2 5].", keys)
+	}
+}
+
+// TestHandleListDerivedAccounts_rangeFilter verifies start/end parameters filter the results.
+func TestHandleListDerivedAccounts_rangeFilter(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wrange", testMnemonic)
+	for _, idx := range []string{"0", "1", "2", "3", "4"} {
+		mustPutDerivedAccount(ctx, t, s, "wrange", idx, testMnemonic)
+	}
+	req := &logical.Request{Storage: s}
+
+	resp, err := handleListDerivedAccounts(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wrange",
+		"start":     "1",
+		"end":       "3",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, _ := resp.Data["keys"].([]string)
+	if len(keys) != 3 || keys[0] != "1" || keys[1] != "2" || keys[2] != "3" {
+		t.Fatalf("keys=%v want [1 2 3].", keys)
+	}
+}
+
+// TestHandleListDerivedAccounts_startOnly verifies only start bound filters correctly.
+func TestHandleListDerivedAccounts_startOnly(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wstart", testMnemonic)
+	for _, idx := range []string{"0", "1", "2", "3"} {
+		mustPutDerivedAccount(ctx, t, s, "wstart", idx, testMnemonic)
+	}
+	req := &logical.Request{Storage: s}
+
+	resp, err := handleListDerivedAccounts(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wstart",
+		"start":     "2",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, _ := resp.Data["keys"].([]string)
+	if len(keys) != 2 || keys[0] != "2" || keys[1] != "3" {
+		t.Fatalf("keys=%v want [2 3].", keys)
+	}
+}
+

--- a/internal/path/wallet/crud_test.go
+++ b/internal/path/wallet/crud_test.go
@@ -660,6 +660,48 @@ func TestHandleListDerivedAccounts_rangeFilter(t *testing.T) {
 	}
 }
 
+// TestHandleListDerivedAccounts_startExceedsMax verifies start > MaxBIP44AddressIndex returns an error.
+func TestHandleListDerivedAccounts_startExceedsMax(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wmax", testMnemonic)
+	req := &logical.Request{Storage: s}
+
+	resp, err := handleListDerivedAccounts(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wmax",
+		"start":     "2147483648",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatal("expected error response for start > MaxBIP44AddressIndex.")
+	}
+}
+
+// TestHandleListDerivedAccounts_endExceedsMax verifies end > MaxBIP44AddressIndex returns an error.
+func TestHandleListDerivedAccounts_endExceedsMax(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wmaxend", testMnemonic)
+	req := &logical.Request{Storage: s}
+
+	resp, err := handleListDerivedAccounts(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wmaxend",
+		"end":       "2147483648",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatal("expected error response for end > MaxBIP44AddressIndex.")
+	}
+}
+
 // faultStorage wraps logical.InmemStorage and returns an error when Put is called with a
 // key matching faultKey. After faultRemaining reaches zero the fault is cleared and
 // subsequent Puts succeed normally.

--- a/internal/path/wallet/crud_test.go
+++ b/internal/path/wallet/crud_test.go
@@ -210,9 +210,9 @@ func TestHandleWalletSignEIP712_recoversAddress(t *testing.T) {
 
 	req := &logical.Request{Storage: s}
 	resp, err := handleWalletSignEIP712(ctx, req, walletFieldData(map[string]interface{}{
-		"wallet_id":    "w3",
-		"index":        "0",
-		"payload":      payload,
+		"wallet_id": "w3",
+		"index":     "0",
+		"payload":   payload,
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -784,8 +784,8 @@ func TestHandleListDerivedAccounts_noRange(t *testing.T) {
 	}
 }
 
-// TestHandleListDerivedAccounts_rangeFilter verifies start/end parameters filter the results.
-func TestHandleListDerivedAccounts_rangeFilter(t *testing.T) {
+// TestHandleListDerivedAccounts_ignoresStartEnd verifies LIST returns all indices; start/end are not filters.
+func TestHandleListDerivedAccounts_ignoresStartEnd(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -805,50 +805,148 @@ func TestHandleListDerivedAccounts_rangeFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 	keys, _ := resp.Data["keys"].([]string)
-	if len(keys) != 3 || keys[0] != "1" || keys[1] != "2" || keys[2] != "3" {
-		t.Fatalf("keys=%v want [1 2 3].", keys)
+	if len(keys) != 5 || keys[0] != "0" || keys[4] != "4" {
+		t.Fatalf("keys=%v want [0 1 2 3 4].", keys)
 	}
 }
 
-// TestHandleListDerivedAccounts_startExceedsMax verifies start > MaxBIP44AddressIndex returns an error.
-func TestHandleListDerivedAccounts_startExceedsMax(t *testing.T) {
+// TestHandleReadDerivedAccountsRange_success verifies inclusive range returns full metadata.
+func TestHandleReadDerivedAccountsRange_success(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	s := new(logical.InmemStorage)
-	mustPutWalletSeed(ctx, t, s, "wmax", testMnemonic)
+	mustPutWalletSeed(ctx, t, s, "wmeta", testMnemonic)
+	for _, idx := range []string{"0", "1", "2"} {
+		mustPutDerivedAccount(ctx, t, s, "wmeta", idx, testMnemonic)
+	}
 	req := &logical.Request{Storage: s}
 
-	resp, err := handleListDerivedAccounts(ctx, req, walletFieldData(map[string]interface{}{
-		"wallet_id": "wmax",
-		"start":     "2147483648",
+	resp, err := handleReadDerivedAccountsRange(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wmeta",
+		"start":     "1",
+		"end":       "2",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.IsError() {
+		t.Fatalf("unexpected error: %v", resp)
+	}
+	accts, _ := resp.Data["accounts"].([]interface{})
+	if len(accts) != 2 {
+		t.Fatalf("len(accounts)=%d want 2.", len(accts))
+	}
+}
+
+// TestHandleReadDerivedAccountsRange_missingIndex verifies a gap in the range returns an error.
+func TestHandleReadDerivedAccountsRange_missingIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wgap", testMnemonic)
+	mustPutDerivedAccount(ctx, t, s, "wgap", "0", testMnemonic)
+	mustPutDerivedAccount(ctx, t, s, "wgap", "2", testMnemonic)
+	req := &logical.Request{Storage: s}
+
+	resp, err := handleReadDerivedAccountsRange(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wgap",
+		"start":     "0",
+		"end":       "2",
 	}))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatal("expected error response for start > MaxBIP44AddressIndex.")
+		t.Fatal("expected error when index 1 is missing.")
 	}
 }
 
-// TestHandleListDerivedAccounts_endExceedsMax verifies end > MaxBIP44AddressIndex returns an error.
-func TestHandleListDerivedAccounts_endExceedsMax(t *testing.T) {
+// TestHandleReadDerivedAccountsRange_spanExceedsMax verifies span > maxBulkReadDerivedSpan errors.
+func TestHandleReadDerivedAccountsRange_spanExceedsMax(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
 	s := new(logical.InmemStorage)
-	mustPutWalletSeed(ctx, t, s, "wmaxend", testMnemonic)
+	mustPutWalletSeed(ctx, t, s, "wspan2", testMnemonic)
 	req := &logical.Request{Storage: s}
 
-	resp, err := handleListDerivedAccounts(ctx, req, walletFieldData(map[string]interface{}{
-		"wallet_id": "wmaxend",
-		"end":       "2147483648",
+	resp, err := handleReadDerivedAccountsRange(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wspan2",
+		"start":     "0",
+		"end":       "10000",
 	}))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if resp == nil || !resp.IsError() {
-		t.Fatal("expected error response for end > MaxBIP44AddressIndex.")
+		t.Fatal("expected error for span > maxBulkReadDerivedSpan.")
+	}
+}
+
+// TestHandleReadDerivedAccountsRange_startAfterEnd verifies start > end returns a logical error.
+func TestHandleReadDerivedAccountsRange_startAfterEnd(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "word", testMnemonic)
+	mustPutDerivedAccount(ctx, t, s, "word", "1", testMnemonic)
+	req := &logical.Request{Storage: s}
+
+	resp, err := handleReadDerivedAccountsRange(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "word",
+		"start":     "2",
+		"end":       "1",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatal("expected error when start > end.")
+	}
+}
+
+// TestHandleReadDerivedAccountsRange_missingStart verifies omitting start returns a logical error.
+func TestHandleReadDerivedAccountsRange_missingStart(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wmissstart", testMnemonic)
+	req := &logical.Request{Storage: s}
+
+	resp, err := handleReadDerivedAccountsRange(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wmissstart",
+		"end":       "2",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatal("expected error when start is missing.")
+	}
+}
+
+// TestHandleReadDerivedAccountsRange_missingEnd verifies omitting end returns a logical error.
+func TestHandleReadDerivedAccountsRange_missingEnd(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wmissend", testMnemonic)
+	req := &logical.Request{Storage: s}
+
+	resp, err := handleReadDerivedAccountsRange(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wmissend",
+		"start":     "0",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatal("expected error when end is missing.")
 	}
 }
 
@@ -956,4 +1054,3 @@ func TestHandleDerivedAccountCreate_updateOperationCreatesAccount(t *testing.T) 
 		t.Fatal("expected non-empty address.")
 	}
 }
-

--- a/internal/path/wallet/crud_test.go
+++ b/internal/path/wallet/crud_test.go
@@ -46,6 +46,7 @@ func walletFieldData(raw map[string]interface{}) *framework.FieldData {
 		"index",
 		"start",
 		"end",
+		"count",
 		"data",
 		"to",
 		"address_to",
@@ -607,6 +608,155 @@ func TestHandleDerivedAccountCreate_missingWalletReturnsLogicalError(t *testing.
 	}
 	if resp == nil || !resp.IsError() {
 		t.Fatal("expected error response for missing wallet.")
+	}
+}
+
+// TestHandleBatchDerivedAccounts_success verifies three accounts are created with consecutive indices.
+func TestHandleBatchDerivedAccounts_success(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wbatch", testMnemonic)
+	req := &logical.Request{Storage: s}
+
+	var walletMu sync.Map
+	handler := makeHandleBatchDerivedAccountCreate(&walletMu)
+
+	resp, err := handler(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wbatch",
+		"count":     "3",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.IsError() {
+		t.Fatalf("unexpected error: %v", resp)
+	}
+	accts, ok := resp.Data["accounts"].([]interface{})
+	if !ok || len(accts) != 3 {
+		t.Fatalf("accounts=%T %v want 3 elements.", resp.Data["accounts"], resp.Data["accounts"])
+	}
+	for i, wantIdx := range []string{"0", "1", "2"} {
+		m, ok := accts[i].(map[string]interface{})
+		if !ok {
+			t.Fatalf("accounts[%d] type=%T.", i, accts[i])
+		}
+		if got := m["account_index"]; got != wantIdx {
+			t.Fatalf("accounts[%d].account_index=%v want %s.", i, got, wantIdx)
+		}
+		if m["address"] == "" || m["derivation_path"] == "" {
+			t.Fatalf("accounts[%d] missing address or path: %#v.", i, m)
+		}
+	}
+	next, err := ReadWalletCounter(ctx, s, "wbatch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != 3 {
+		t.Fatalf("counter next=%d want 3.", next)
+	}
+}
+
+// TestHandleBatchDerivedAccounts_exceedsMax verifies count above max returns a logical error.
+func TestHandleBatchDerivedAccounts_exceedsMax(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wmaxb", testMnemonic)
+	req := &logical.Request{Storage: s}
+
+	var walletMu sync.Map
+	handler := makeHandleBatchDerivedAccountCreate(&walletMu)
+
+	resp, err := handler(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wmaxb",
+		"count":     "10001",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatal("expected error for count > maxBatchDerivedAccounts.")
+	}
+}
+
+// TestHandleBatchDerivedAccounts_rejectsWhenWouldExceedBIP44Range verifies the batch is rejected
+// upfront (no partial accounts) when the counter is already at the last valid index.
+func TestHandleBatchDerivedAccounts_rejectsWhenWouldExceedBIP44Range(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wspan", testMnemonic)
+	if err := WriteWalletCounter(ctx, s, "wspan", model.MaxBIP44AddressIndex); err != nil {
+		t.Fatal(err)
+	}
+	req := &logical.Request{Storage: s}
+
+	var walletMu sync.Map
+	handler := makeHandleBatchDerivedAccountCreate(&walletMu)
+
+	resp, err := handler(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wspan",
+		"count":     "2",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || !resp.IsError() {
+		t.Fatal("expected error when batch would exceed BIP-44 max index.")
+	}
+	next, err := ReadWalletCounter(ctx, s, "wspan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if next != model.MaxBIP44AddressIndex {
+		t.Fatalf("counter next=%d want unchanged %d.", next, model.MaxBIP44AddressIndex)
+	}
+}
+
+// TestHandleBatchDerivedAccounts_afterSingle verifies batch continues counter after a single create.
+func TestHandleBatchDerivedAccounts_afterSingle(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wmix", testMnemonic)
+	req := &logical.Request{Storage: s}
+
+	var walletMu sync.Map
+	single := makeHandleDerivedAccountCreate(&walletMu)
+	batch := makeHandleBatchDerivedAccountCreate(&walletMu)
+
+	resp1, err := single(ctx, req, walletFieldData(map[string]interface{}{"wallet_id": "wmix"}))
+	if err != nil || resp1 == nil || resp1.IsError() {
+		t.Fatalf("single create: %v %v", err, resp1)
+	}
+	if resp1.Data["account_index"] != "0" {
+		t.Fatalf("first index=%v want 0.", resp1.Data["account_index"])
+	}
+
+	resp2, err := batch(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wmix",
+		"count":     "2",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp2 == nil || resp2.IsError() {
+		t.Fatalf("batch: %v", resp2)
+	}
+	accts, _ := resp2.Data["accounts"].([]interface{})
+	if len(accts) != 2 {
+		t.Fatalf("len(accounts)=%d want 2.", len(accts))
+	}
+	if m0 := accts[0].(map[string]interface{}); m0["account_index"] != "1" {
+		t.Fatalf("batch[0] index=%v want 1.", m0["account_index"])
+	}
+	if m1 := accts[1].(map[string]interface{}); m1["account_index"] != "2" {
+		t.Fatalf("batch[1] index=%v want 2.", m1["account_index"])
 	}
 }
 

--- a/internal/path/wallet/crud_test.go
+++ b/internal/path/wallet/crud_test.go
@@ -19,6 +19,7 @@ package wallet
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
@@ -659,28 +660,108 @@ func TestHandleListDerivedAccounts_rangeFilter(t *testing.T) {
 	}
 }
 
-// TestHandleListDerivedAccounts_startOnly verifies only start bound filters correctly.
-func TestHandleListDerivedAccounts_startOnly(t *testing.T) {
+// faultStorage wraps logical.InmemStorage and returns an error when Put is called with a
+// key matching faultKey. After faultRemaining reaches zero the fault is cleared and
+// subsequent Puts succeed normally.
+type faultStorage struct {
+	logical.Storage
+	faultKey       string
+	faultRemaining int
+}
+
+func (f *faultStorage) Put(ctx context.Context, entry *logical.StorageEntry) error {
+	if f.faultRemaining > 0 && entry.Key == f.faultKey {
+		f.faultRemaining--
+		return fmt.Errorf("injected Put failure for %q", entry.Key)
+	}
+	return f.Storage.Put(ctx, entry)
+}
+
+// TestHandleDerivedAccountCreate_partialWriteSelfHeals verifies that when WriteWalletCounter
+// fails after a successful Put(account), a retry derives the same address at the same index
+// and succeeds — confirming the deterministic BIP-44 derivation self-heals the partial write.
+func TestHandleDerivedAccountCreate_partialWriteSelfHeals(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
-	s := new(logical.InmemStorage)
-	mustPutWalletSeed(ctx, t, s, "wstart", testMnemonic)
-	for _, idx := range []string{"0", "1", "2", "3"} {
-		mustPutDerivedAccount(ctx, t, s, "wstart", idx, testMnemonic)
-	}
-	req := &logical.Request{Storage: s}
+	inner := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, inner, "wpartial", testMnemonic)
 
-	resp, err := handleListDerivedAccounts(ctx, req, walletFieldData(map[string]interface{}{
-		"wallet_id": "wstart",
-		"start":     "2",
+	// Fail the first WriteWalletCounter (counter key Put) only.
+	fs := &faultStorage{
+		Storage:        inner,
+		faultKey:       storagekey.CounterKey("wpartial"),
+		faultRemaining: 1,
+	}
+	req := &logical.Request{Storage: fs}
+
+	var walletMu sync.Map
+	handler := makeHandleDerivedAccountCreate(&walletMu)
+
+	// First attempt: account is written but counter Put fails → handler returns error.
+	_, err := handler(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wpartial",
+	}))
+	if err == nil {
+		t.Fatal("expected error from injected counter Put failure.")
+	}
+
+	// Retry: fault is cleared; counter still reads 0 so same index is re-derived.
+	resp, err := handler(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wpartial",
 	}))
 	if err != nil {
 		t.Fatal(err)
 	}
-	keys, _ := resp.Data["keys"].([]string)
-	if len(keys) != 2 || keys[0] != "2" || keys[1] != "3" {
-		t.Fatalf("keys=%v want [2 3].", keys)
+	if resp == nil || resp.IsError() {
+		t.Fatalf("unexpected error on retry: %v", resp)
+	}
+	// Index must still be 0 — same account, no gap introduced.
+	if got := resp.Data["account_index"]; got != "0" {
+		t.Fatalf("account_index=%v want 0 after self-heal.", got)
+	}
+
+	// Subsequent create must advance to index 1.
+	resp2, err := handler(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wpartial",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := resp2.Data["account_index"]; got != "1" {
+		t.Fatalf("account_index=%v want 1 after self-heal.", got)
+	}
+}
+
+// TestHandleDerivedAccountCreate_updateOperationCreatesAccount verifies that UpdateOperation
+// routes to the same handler as CreateOperation and produces a valid account.
+func TestHandleDerivedAccountCreate_updateOperationCreatesAccount(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+	mustPutWalletSeed(ctx, t, s, "wupdate", testMnemonic)
+
+	// UpdateOperation uses the same handler; simulate it by calling the handler directly.
+	req := &logical.Request{Storage: s, Operation: logical.UpdateOperation}
+
+	var walletMu sync.Map
+	handler := makeHandleDerivedAccountCreate(&walletMu)
+
+	resp, err := handler(ctx, req, walletFieldData(map[string]interface{}{
+		"wallet_id": "wupdate",
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp == nil || resp.IsError() {
+		t.Fatalf("UpdateOperation: unexpected error response: %v", resp)
+	}
+	if got := resp.Data["account_index"]; got != "0" {
+		t.Fatalf("account_index=%v want 0.", got)
+	}
+	if resp.Data["address"] == "" {
+		t.Fatal("expected non-empty address.")
 	}
 }
 

--- a/internal/path/wallet/paths.go
+++ b/internal/path/wallet/paths.go
@@ -106,12 +106,12 @@ func pathWalletImport() *framework.Path {
 	}
 }
 
-// pathDerivedAccount registers CRUD-style access on wallets/:wallet_id/accounts/:index.
+// pathDerivedAccount registers read access on wallets/:wallet_id/accounts/:index.
 func pathDerivedAccount() *framework.Path {
 	walletID := framework.GenericNameRegex("wallet_id")
 	return &framework.Path{
 		Pattern:      "wallets/" + walletID + "/accounts/(?P<index>\\d+)",
-		HelpSynopsis: "Create, update, or read a derived Ethereum account at m/44'/60'/0'/0/<index>",
+		HelpSynopsis: "Read a derived Ethereum account at m/44'/60'/0'/0/<index>.",
 		Fields: map[string]*framework.FieldSchema{
 			"wallet_id": {
 				Type:        framework.TypeString,
@@ -124,25 +124,35 @@ func pathDerivedAccount() *framework.Path {
 		},
 		ExistenceCheck: ExistenceWalletDerivedAccount(),
 		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ReadOperation:   handleDerivedAccountRead,
-			logical.CreateOperation: handleDerivedAccountCreate,
-			logical.UpdateOperation: handleDerivedAccountUpdateConflict,
+			logical.ReadOperation: handleDerivedAccountRead,
 		},
 	}
 }
 
-// pathListDerivedAccounts registers LIST on wallets/:wallet_id/accounts/ for index keys.
+// pathListDerivedAccounts registers LIST and auto-create on wallets/:wallet_id/accounts/.
+// LIST accepts optional start and end query parameters to filter indices (inclusive range).
+// POST derives and stores the next account using the auto-increment counter.
 func pathListDerivedAccounts() *framework.Path {
 	walletID := framework.GenericNameRegex("wallet_id")
 	return &framework.Path{
 		Pattern:      "wallets/" + walletID + "/accounts/?",
-		HelpSynopsis: "List derived account indices with address and derivation_path",
+		HelpSynopsis: "List derived account indices (with optional range filter) or auto-create the next account.",
 		Fields: map[string]*framework.FieldSchema{
 			"wallet_id": {Type: framework.TypeString},
+			"start": {
+				Type:        framework.TypeString,
+				Description: "Inclusive lower bound for index range filter (non-negative integer). Optional.",
+			},
+			"end": {
+				Type:        framework.TypeString,
+				Description: "Inclusive upper bound for index range filter (non-negative integer). Optional.",
+			},
 		},
-		ExistenceCheck: nil,
+		ExistenceCheck: ExistenceWalletDerivedAccountsRoot(),
 		Callbacks: map[logical.Operation]framework.OperationFunc{
-			logical.ListOperation: handleListDerivedAccounts,
+			logical.ListOperation:   handleListDerivedAccounts,
+			logical.CreateOperation: handleDerivedAccountCreate,
+			logical.UpdateOperation: handleDerivedAccountCreate,
 		},
 	}
 }

--- a/internal/path/wallet/paths.go
+++ b/internal/path/wallet/paths.go
@@ -154,29 +154,30 @@ func pathBatchDerivedAccounts(walletMu *sync.Map) *framework.Path {
 	}
 }
 
-// pathListDerivedAccounts registers LIST and auto-create on wallets/:wallet_id/accounts/.
-// LIST accepts optional start and end query parameters to filter indices (inclusive range).
+// pathListDerivedAccounts registers LIST, auto-create, and range-read on wallets/:wallet_id/accounts/.
 // POST derives and stores the next account using the auto-increment counter; walletMu ensures
 // the counter read-increment-write sequence is atomic within a single Vault active node.
+// GET (ReadOperation) with query params start and end returns an inclusive range of account metadata.
 func pathListDerivedAccounts(walletMu *sync.Map) *framework.Path {
 	walletID := framework.GenericNameRegex("wallet_id")
 	return &framework.Path{
 		Pattern:      "wallets/" + walletID + "/accounts/?",
-		HelpSynopsis: "List derived account indices (with optional range filter) or auto-create the next account.",
+		HelpSynopsis: "List derived account indices, auto-create the next account, or range-read account metadata.",
 		Fields: map[string]*framework.FieldSchema{
 			"wallet_id": {Type: framework.TypeString},
 			"start": {
 				Type:        framework.TypeString,
-				Description: "Inclusive lower bound for index range filter (non-negative integer). Optional.",
+				Description: "Inclusive lower index for range read (required with end; use with GET).",
 			},
 			"end": {
 				Type:        framework.TypeString,
-				Description: "Inclusive upper bound for index range filter (non-negative integer). Optional.",
+				Description: "Inclusive upper index for range read (required with start; use with GET).",
 			},
 		},
 		ExistenceCheck: ExistenceWalletDerivedAccountsRoot(),
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.ListOperation:   handleListDerivedAccounts,
+			logical.ReadOperation:   handleReadDerivedAccountsRange,
 			logical.CreateOperation: makeHandleDerivedAccountCreate(walletMu),
 			logical.UpdateOperation: makeHandleDerivedAccountCreate(walletMu),
 		},

--- a/internal/path/wallet/paths.go
+++ b/internal/path/wallet/paths.go
@@ -29,6 +29,7 @@ func Paths(walletMu *sync.Map) []*framework.Path {
 		pathWalletCreateAuto(),
 		pathWalletImport(),
 		pathDerivedAccount(),
+		pathBatchDerivedAccounts(walletMu),
 		pathListDerivedAccounts(walletMu),
 		pathWalletSignTxLegacy(),
 		pathWalletSignTxEIP1559(),
@@ -126,6 +127,29 @@ func pathDerivedAccount() *framework.Path {
 		ExistenceCheck: ExistenceWalletDerivedAccount(),
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.ReadOperation: handleDerivedAccountRead,
+		},
+	}
+}
+
+// pathBatchDerivedAccounts registers POST on wallets/:wallet_id/accounts/batch to create
+// multiple derived accounts in one request (bounded by maxBatchDerivedAccounts in crud.go).
+func pathBatchDerivedAccounts(walletMu *sync.Map) *framework.Path {
+	walletID := framework.GenericNameRegex("wallet_id")
+	return &framework.Path{
+		Pattern:      "wallets/" + walletID + "/accounts/batch",
+		HelpSynopsis: "Create multiple derived Ethereum accounts at consecutive counter indices.",
+		Fields: map[string]*framework.FieldSchema{
+			"wallet_id": {Type: framework.TypeString},
+			"count": {
+				Type:        framework.TypeString,
+				Required:    true,
+				Description: "Number of accounts to create (positive integer, max 10000).",
+			},
+		},
+		ExistenceCheck: ExistenceWalletDerivedAccountsRoot(),
+		Callbacks: map[logical.Operation]framework.OperationFunc{
+			logical.CreateOperation: makeHandleBatchDerivedAccountCreate(walletMu),
+			logical.UpdateOperation: makeHandleBatchDerivedAccountCreate(walletMu),
 		},
 	}
 }

--- a/internal/path/wallet/paths.go
+++ b/internal/path/wallet/paths.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -22,13 +23,13 @@ import (
 )
 
 // Paths returns all wallet (HD) paths.
-func Paths() []*framework.Path {
+func Paths(walletMu *sync.Map) []*framework.Path {
 	return []*framework.Path{
 		pathListWallets(),
 		pathWalletCreateAuto(),
 		pathWalletImport(),
 		pathDerivedAccount(),
-		pathListDerivedAccounts(),
+		pathListDerivedAccounts(walletMu),
 		pathWalletSignTxLegacy(),
 		pathWalletSignTxEIP1559(),
 		pathWalletSign(),
@@ -131,8 +132,9 @@ func pathDerivedAccount() *framework.Path {
 
 // pathListDerivedAccounts registers LIST and auto-create on wallets/:wallet_id/accounts/.
 // LIST accepts optional start and end query parameters to filter indices (inclusive range).
-// POST derives and stores the next account using the auto-increment counter.
-func pathListDerivedAccounts() *framework.Path {
+// POST derives and stores the next account using the auto-increment counter; walletMu ensures
+// the counter read-increment-write sequence is atomic within a single Vault active node.
+func pathListDerivedAccounts(walletMu *sync.Map) *framework.Path {
 	walletID := framework.GenericNameRegex("wallet_id")
 	return &framework.Path{
 		Pattern:      "wallets/" + walletID + "/accounts/?",
@@ -151,8 +153,8 @@ func pathListDerivedAccounts() *framework.Path {
 		ExistenceCheck: ExistenceWalletDerivedAccountsRoot(),
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.ListOperation:   handleListDerivedAccounts,
-			logical.CreateOperation: handleDerivedAccountCreate,
-			logical.UpdateOperation: handleDerivedAccountCreate,
+			logical.CreateOperation: makeHandleDerivedAccountCreate(walletMu),
+			logical.UpdateOperation: makeHandleDerivedAccountCreate(walletMu),
 		},
 	}
 }

--- a/internal/path/wallet/paths_test.go
+++ b/internal/path/wallet/paths_test.go
@@ -19,6 +19,7 @@ package wallet
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/vault/sdk/framework"
@@ -45,7 +46,8 @@ func pathRegisteredOps(p *framework.Path) map[logical.Operation]bool {
 func TestPaths_registerUpdateOnWriteEndpoints(t *testing.T) {
 	t.Parallel()
 
-	paths := Paths()
+	var walletMu sync.Map
+	paths := Paths(&walletMu)
 	if len(paths) == 0 {
 		t.Fatal("expected non-empty paths.")
 	}

--- a/internal/path/wallet/paths_test.go
+++ b/internal/path/wallet/paths_test.go
@@ -119,3 +119,28 @@ func TestPaths_batchDerivedAccounts_registersCreateUpdate(t *testing.T) {
 		t.Fatal("missing wallets/*/accounts/batch path.")
 	}
 }
+
+// TestPaths_listDerivedAccounts_registersRead verifies the accounts/? path wires ReadOperation
+// alongside the existing List, Create, and Update operations.
+func TestPaths_listDerivedAccounts_registersRead(t *testing.T) {
+	t.Parallel()
+
+	var walletMu sync.Map
+	for _, p := range Paths(&walletMu) {
+		if p == nil || !strings.HasSuffix(p.Pattern, "/accounts/?") {
+			continue
+		}
+		ops := pathRegisteredOps(p)
+		if !ops[logical.ReadOperation] {
+			t.Fatalf("pattern %q missing ReadOperation.", p.Pattern)
+		}
+		if !ops[logical.ListOperation] {
+			t.Fatalf("pattern %q missing ListOperation.", p.Pattern)
+		}
+		if !ops[logical.CreateOperation] || !ops[logical.UpdateOperation] {
+			t.Fatalf("pattern %q missing Create+Update.", p.Pattern)
+		}
+		return
+	}
+	t.Fatal("missing wallets/*/accounts/? path.")
+}

--- a/internal/path/wallet/paths_test.go
+++ b/internal/path/wallet/paths_test.go
@@ -94,3 +94,28 @@ func TestPaths_registerUpdateOnWriteEndpoints(t *testing.T) {
 		}
 	}
 }
+
+// TestPaths_batchDerivedAccounts_registersCreateUpdate verifies batch path wires Create and Update.
+func TestPaths_batchDerivedAccounts_registersCreateUpdate(t *testing.T) {
+	t.Parallel()
+
+	var walletMu sync.Map
+	paths := Paths(&walletMu)
+	var batchPattern string
+	for _, p := range paths {
+		if p == nil {
+			continue
+		}
+		if strings.HasSuffix(p.Pattern, "/accounts/batch") {
+			batchPattern = p.Pattern
+			ops := pathRegisteredOps(p)
+			if !ops[logical.CreateOperation] || !ops[logical.UpdateOperation] {
+				t.Fatalf("pattern %q ops=%v want Create+Update.", p.Pattern, ops)
+			}
+			break
+		}
+	}
+	if batchPattern == "" {
+		t.Fatal("missing wallets/*/accounts/batch path.")
+	}
+}

--- a/internal/path/wallet/storage.go
+++ b/internal/path/wallet/storage.go
@@ -58,6 +58,27 @@ func ExistenceWalletSeed() framework.ExistenceFunc {
 	}
 }
 
+// ExistenceWalletDerivedAccountsRoot satisfies the framework rule that any path registering
+// CreateOperation must define an ExistenceCheck. The URL wallets/:id/accounts/ is not a single
+// storage object (accounts live under .../accounts/<index>), so the bool is always false so
+// writes keep routing to Create (stable ACL vs tying "exists" to seed presence).
+//
+// It still mirrors ExistenceWalletSeed-style checks: require wallet_id, propagate storage Get
+// errors, and touch the seed key so a broken backend fails here instead of only inside the handler.
+func ExistenceWalletDerivedAccountsRoot() framework.ExistenceFunc {
+	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (bool, error) {
+		walletID := model.NewFieldDataWrapper(data).GetString("wallet_id", "")
+		if walletID == "" {
+			return false, nil
+		}
+		_, err := req.Storage.Get(ctx, storagekey.SeedKey(walletID))
+		if err != nil {
+			return false, fmt.Errorf("wallet existence check for derived accounts root %s: %w", walletID, err)
+		}
+		return false, nil
+	}
+}
+
 // ExistenceWalletDerivedAccount returns true when storage has a derived account for wallet_id and index.
 func ExistenceWalletDerivedAccount() framework.ExistenceFunc {
 	return func(ctx context.Context, req *logical.Request, data *framework.FieldData) (bool, error) {
@@ -88,6 +109,34 @@ func ReadWalletSeed(ctx context.Context, s logical.Storage, walletID string) (*m
 		return nil, fmt.Errorf("decode wallet seed %s: %w", walletID, err)
 	}
 	return &seed, nil
+}
+
+// ReadWalletCounter loads the auto-increment counter for walletID, returning 0 if not yet set.
+func ReadWalletCounter(ctx context.Context, s logical.Storage, walletID string) (uint32, error) {
+	entry, err := s.Get(ctx, storagekey.CounterKey(walletID))
+	if err != nil {
+		return 0, fmt.Errorf("get wallet counter %s: %w", walletID, err)
+	}
+	if entry == nil {
+		return 0, nil
+	}
+	var counter model.WalletCounter
+	if err := entry.DecodeJSON(&counter); err != nil {
+		return 0, fmt.Errorf("decode wallet counter %s: %w", walletID, err)
+	}
+	return counter.NextIndex, nil
+}
+
+// WriteWalletCounter persists the next auto-increment index for walletID.
+func WriteWalletCounter(ctx context.Context, s logical.Storage, walletID string, next uint32) error {
+	entry, err := logical.StorageEntryJSON(storagekey.CounterKey(walletID), &model.WalletCounter{NextIndex: next})
+	if err != nil {
+		return fmt.Errorf("encode wallet counter %s: %w", walletID, err)
+	}
+	if err := s.Put(ctx, entry); err != nil {
+		return fmt.Errorf("put wallet counter %s: %w", walletID, err)
+	}
+	return nil
 }
 
 // ParseAddressIndex parses a non-negative decimal index string within BIP-44 address_index bounds.

--- a/internal/path/wallet/storage_test.go
+++ b/internal/path/wallet/storage_test.go
@@ -129,6 +129,77 @@ func TestExistenceWalletSeed(t *testing.T) {
 	})
 }
 
+func TestExistenceWalletDerivedAccountsRoot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("empty_wallet_id_returns_false", func(t *testing.T) {
+		t.Parallel()
+		req := &logical.Request{Storage: new(logical.InmemStorage)}
+		exists, err := walletpkg.ExistenceWalletDerivedAccountsRoot()(ctx, req, walletStorageFieldData(map[string]interface{}{
+			"wallet_id": "",
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exists {
+			t.Fatal("exists=true want false.")
+		}
+	})
+
+	t.Run("missing_seed_still_returns_false_exists", func(t *testing.T) {
+		t.Parallel()
+		req := &logical.Request{Storage: new(logical.InmemStorage)}
+		exists, err := walletpkg.ExistenceWalletDerivedAccountsRoot()(ctx, req, walletStorageFieldData(map[string]interface{}{
+			"wallet_id": "w_no_seed",
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exists {
+			t.Fatal("exists=true want false.")
+		}
+	})
+
+	t.Run("seed_present_still_returns_false_exists", func(t *testing.T) {
+		t.Parallel()
+		s := new(logical.InmemStorage)
+		req := &logical.Request{Storage: s}
+		entry, err := logical.StorageEntryJSON(storagekey.SeedKey("w_root"), &model.WalletSeed{Mnemonic: testMnemonic})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Put(ctx, entry); err != nil {
+			t.Fatal(err)
+		}
+		exists, err := walletpkg.ExistenceWalletDerivedAccountsRoot()(ctx, req, walletStorageFieldData(map[string]interface{}{
+			"wallet_id": "w_root",
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if exists {
+			t.Fatal("exists=true want false (URL is not a singleton object).")
+		}
+	})
+
+	t.Run("storage_get_error_returns_error", func(t *testing.T) {
+		t.Parallel()
+		sentinel := errors.New("boom")
+		req := &logical.Request{Storage: &getErrorStorage{err: sentinel}}
+		_, err := walletpkg.ExistenceWalletDerivedAccountsRoot()(ctx, req, walletStorageFieldData(map[string]interface{}{
+			"wallet_id": "w_err",
+		}))
+		if err == nil {
+			t.Fatal("expected error.")
+		}
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("got %v want %v.", err, sentinel)
+		}
+	})
+}
+
 func TestExistenceWalletDerivedAccount(t *testing.T) {
 	t.Parallel()
 
@@ -383,4 +454,34 @@ func TestPrivateKeyECDSA_compatibleWithGoEthereumSign(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// TestReadWriteWalletCounter verifies counter defaults to 0 when absent and persists correctly.
+func TestReadWriteWalletCounter(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	s := new(logical.InmemStorage)
+
+	// Absent counter returns 0.
+	got, err := walletpkg.ReadWalletCounter(ctx, s, "wctr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 0 {
+		t.Fatalf("counter=%d want 0.", got)
+	}
+
+	// Write and read back.
+	if err := walletpkg.WriteWalletCounter(ctx, s, "wctr", 42); err != nil {
+		t.Fatal(err)
+	}
+	got, err = walletpkg.ReadWalletCounter(ctx, s, "wctr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 42 {
+		t.Fatalf("counter=%d want 42.", got)
+	}
+}
+
 

--- a/scripts/e2e-sepolia-js/README.md
+++ b/scripts/e2e-sepolia-js/README.md
@@ -1,0 +1,104 @@
+# Sepolia + Vault HTTP 本地測試（Node + ethers）
+
+用 **Vault HTTP API**（`fetch`）操作 `blockchain/` 外掛，並用 **ethers.js v6** 在指定 **EVM chain id**（預設 **Sepolia `11155111`**，可用 **`E2E_CHAIN_ID`** 覆寫）驗證簽名、EIP-712、ECIES 與可選的鏈上廣播。**`SEPOLIA_RPC_URL` 必須對應同一條鏈**（變數名沿用，可填任意相容的 JSON-RPC URL）。
+
+僅供本機／開發測試；請勿把 `VAULT_TOKEN`、助記詞寫進版本庫。
+
+## 前置
+
+1. 本機已跑 Vault，且已掛載 `blockchain/`（例如 `make setup-plugin-local`）。
+2. Node 18+。
+3. Phase 2 需要 Sepolia RPC URL（Infura / Alchemy / 公開 RPC 皆可）。
+
+## 安裝
+
+```bash
+cd scripts/e2e-sepolia-js
+npm install
+```
+
+## Phase 1：建立錢包與帳戶
+
+建立一個 HD 錢包（隨機 24 詞，**不回傳助記詞**）、派生 `index 0`，再建立一個 single-key 帳戶。會寫入目錄下的 `.e2e-sepolia-state.json`（已列入 `.gitignore`）。
+
+```bash
+export VAULT_ADDR=http://127.0.0.1:8200
+export VAULT_TOKEN=root
+node run.mjs phase1
+```
+
+可選環境變數：
+
+| 變數 | 說明 |
+|------|------|
+| `E2E_WALLET` | 自訂 `wallet_id`（預設帶時間戳） |
+| `E2E_ACCOUNT` | 自訂 single-key 名稱 |
+| `KNOWN_MNEMONIC` | 若設定則改走 `import`，地址可與 `e2e_smoke.sh` 相同而可預期 |
+| `KNOWN_PRIVATE_KEY` | 若設定則改走 single-key `import`（私鑰 hex，可含/不含 `0x`） |
+| `E2E_CHAIN_ID` | 目標鏈 **十進位** chain id（預設 `11155111`）；寫入 `.e2e-sepolia-state.json` 的 `chainId` |
+
+完成後依輸出到 Sepolia **水龍頭或自己的錢包** 對兩個地址打測試幣。
+
+## Phase 2：Sepolia 驗證 + 可選廣播
+
+```bash
+export VAULT_TOKEN=root
+export SEPOLIA_RPC_URL=https://sepolia.infura.io/v3/YOUR_KEY
+# 可選：與 phase1 不同鏈時覆寫（優先於 state 檔里的 chainId）
+# export E2E_CHAIN_ID=17000
+node run.mjs phase2
+```
+
+會檢查餘額，並用 ethers 驗證：
+
+- `sign`：`recoverAddress(keccak256(data), signature)` 與 Vault 回傳地址一致。
+- `sign-eip712`：`verifyTypedData` 與 Vault 簽名一致。
+- `encrypt` / `decrypt`：與 `0x68656c6c6f`（`hello`）往返。
+- `sign-tx/eip1559` / `sign-tx/legacy`（**HD**）：解析 `signed_transaction`，比對 chainId / tx hash；`to` 為 single-key 地址。
+- `sign-tx/eip1559` / `sign-tx/legacy`（**single-key**）：同上；`to` 為 HD 地址。
+
+可選：實際發鏈上交易（**HD 與 single-key 至少一個地址有餘額**；各自獨立判斷）：
+
+```bash
+export BROADCAST=1
+node run.mjs phase2
+```
+
+- **HD 有餘額**：廣播兩筆 **`value: 0`** 轉帳到 **single-key**（僅付 gas）：先 **EIP-1559**（nonce `n`），再 **legacy**（`n+1`）。
+- **single-key 有餘額**：再廣播兩筆 **`value: 0`** 轉帳到 **HD**：先 **EIP-1559**，再 **legacy**（各自從該地址的現有 nonce 起算）。
+- 兩邊皆無餘額時會失敗退出。
+
+## Phase 3：合約部署 + access list（EIP-2930）
+
+在 **type-2（EIP-1559）** 交易上帶入 EIP-2930 **`access_list`**（外掛僅支援 `sign-tx/eip1559`，無獨立 type-1 路徑）。腳本會：
+
+1. 用 `ethers.getCreateAddress({ from: HD, nonce })` 預測 **CREATE** 合約地址。
+2. 呼叫 `sign-tx/eip1559`：**省略 `to`**、`data` 為極小部署 bytecode、`access_list` 為 JSON 陣列（含上述地址與 `storageKeys: []`）。
+3. 用 ethers 解析 `signed_transaction`：確認 **type 2**、**to 為 null**、`access_list` 非空且第一筆地址與預測一致。
+
+可選 **上鏈**（需 HD 有足夠 Sepolia ETH 付 gas）：
+
+```bash
+export BROADCAST=1
+node run.mjs phase3
+```
+
+成功後會檢查 `receipt.contractAddress` 與預測地址一致，並讀取 `code` 非空；並再呼叫 **`eth_getTransactionByHash`** 比對 `accessList` 非空（與本地解析一致），表示節點／鏈上資料也帶有 EIP-2930 access list。
+
+### 怎麼知道 `access_list`「有帶上」vs「有幫 gas」
+
+| 層次 | 怎麼驗證 |
+|------|----------|
+| **有帶進交易** | 解析 `signed_transaction`（Phase 3 已做）；或 Etherscan 該筆 tx 的 **Access List**；或 `eth_getTransactionByHash` 回傳的 `accessList`（Phase 3 廣播後會檢查）。 |
+| **有 EIP-2929 預熱效果** | Access list 在執行前把條目裡的 **address / storage** 標成「暖」，可降低之後 **cold** 存取的 gas。要量化需 **對照實驗**：同一邏輯（例如同一 deploy）一筆 `access_list: "[]"`、一筆帶預測地址，比 **`receipt.gasUsed`**（差異可能不大，但非空 list 才有預熱語意）。 |
+
+> **注意**：若已用 Phase 2 `BROADCAST=1` 發過兩筆交易，鏈上 nonce 已前進；Phase 3 每次會讀取**現有** `nonce`，無需手動對齊。
+
+## API 對照
+
+HTTP 路徑為 Vault 慣例：`POST ${VAULT_ADDR}/v1/blockchain/<path>`，標頭 `X-Vault-Token`。詳見專案根目錄 `README.md` 的 API 表。
+
+## 疑難
+
+- **403 / permission denied**：Token policy 需允許 `blockchain/wallets/...`、`blockchain/accounts/...`。
+- **Phase 2 EIP-712 失敗**：確認 `SEPOLIA_RPC_URL` 正確；domain 的 `chainId` 與 **`E2E_CHAIN_ID` / state `chainId`** 及實際 RPC 鏈一致。

--- a/scripts/e2e_smoke.sh
+++ b/scripts/e2e_smoke.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 # End-to-end checks against a live Vault with blockchain/ mounted.
-# Covers: wallet import, read derived, list wallets/accounts, sign, sign-tx/legacy + sign-tx/eip1559,
-# sign-eip712, ECIES encrypt/decrypt roundtrip.
+# Covers: wallet import, auto-derive first account, read derived, list wallets/accounts, sign,
+# sign-tx/legacy + sign-tx/eip1559, sign-eip712, ECIES encrypt/decrypt roundtrip.
 # Uses a fixed BIP-39 test vector so the derived address is deterministic.
 #
 # There is no standalone read/write on blockchain/wallets/:wallet_id (touch was removed); use LIST
 # wallets/ or derived account paths instead.
 #
-# Wallet paths under .../accounts/:index/{sign,sign-tx,...} register both Create and Update with
-# the same handler so Vault can route HTTP writes after ExistenceCheck (usually Update).
+# New derived accounts are created with vault write -force on .../wallets/:id/accounts/ (server picks
+# the next index). Per-index paths .../accounts/:index/{sign,sign-tx,...} still register Create and
+# Update with the same handler so Vault can route HTTP writes after ExistenceCheck (usually Update).
 #
 # If vault read returns 405 unsupported operation after you rebuild the plugin, the mount may
 # still be running an old process — run make setup-plugin-local (catalog + plugin reload).
@@ -57,6 +58,7 @@ EIP712_MESSAGE='{"name":"Cow"}'
 EIP712_PRIMARY_TYPE="Person"
 EIP712_PAYLOAD='{"types":{"EIP712Domain":[{"name":"name","type":"string"}],"Person":[{"name":"name","type":"string"}]},"primaryType":"Person","domain":{"name":"Test Domain"},"message":{"name":"Cow"}}'
 
+wallet_accounts_root="blockchain/wallets/${E2E_WALLET}/accounts/"
 acct_base="blockchain/wallets/${E2E_WALLET}/accounts/0"
 single_base="blockchain/accounts/${E2E_ACCOUNT}"
 
@@ -94,9 +96,15 @@ vault_write_force_json() {
 echo "== import wallet ${E2E_WALLET} (deterministic mnemonic) =="
 vault write "blockchain/wallets/${E2E_WALLET}/import" mnemonic="${MNEMONIC}"
 
-echo "== derive account index 0 =="
-# Vault CLI requires -force when there are no key=value fields; wallet_id and index come from the path.
-vault write -force "${acct_base}"
+echo "== auto-derive first account (assigned index 0) =="
+# Create is on .../accounts/ (no index in path); Vault CLI needs -force when there are no k=v fields.
+DERIVE_JSON="$(vault_write_force_json "${wallet_accounts_root}")"
+IDX="$(require_jq "${DERIVE_JSON}" '.data.account_index // empty' 'expected .data.account_index from derive')"
+if [[ "${IDX}" != "0" ]]; then
+  echo "error: expected first account_index 0, got ${IDX}" >&2
+  echo "${DERIVE_JSON}" >&2
+  exit 1
+fi
 
 echo "== read derived account =="
 OUT="$(vault read -format=json "${acct_base}")"

--- a/scripts/e2e_smoke.sh
+++ b/scripts/e2e_smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # End-to-end checks against a live Vault with blockchain/ mounted.
 # Covers: wallet import, auto-derive first account, batch derive (accounts/batch), read derived,
-# list wallets/accounts, sign, sign-tx/legacy + sign-tx/eip1559, sign-eip712, ECIES encrypt/decrypt
+# list wallets/accounts, range-read derived accounts (GET accounts?start=N&end=M), sign, sign-tx/legacy + sign-tx/eip1559, sign-eip712, ECIES encrypt/decrypt
 # roundtrip.
 # Uses a fixed BIP-39 test vector so the derived address is deterministic.
 #
@@ -62,6 +62,7 @@ EIP712_PAYLOAD='{"types":{"EIP712Domain":[{"name":"name","type":"string"}],"Pers
 
 wallet_accounts_root="blockchain/wallets/${E2E_WALLET}/accounts/"
 wallet_accounts_batch="blockchain/wallets/${E2E_WALLET}/accounts/batch"
+wallet_accounts_read_root="blockchain/wallets/${E2E_WALLET}/accounts"
 acct_base="blockchain/wallets/${E2E_WALLET}/accounts/0"
 single_base="blockchain/accounts/${E2E_ACCOUNT}"
 
@@ -166,6 +167,30 @@ if ! echo "${LIST_ACCTS_JSON}" | jq -e '
   exit 1
 fi
 echo "  list keys OK"
+
+echo "== range-read derived accounts (GET accounts start=2 end=3) =="
+META_JSON="$(vault read -format=json "${wallet_accounts_read_root}" start=2 end=3)"
+META_WID="$(require_jq "${META_JSON}" '.data.wallet_id // empty' 'expected .data.wallet_id from range read')"
+if [[ "${META_WID}" != "${E2E_WALLET}" ]]; then
+  echo "error: range-read wallet_id mismatch: got ${META_WID} want ${E2E_WALLET}" >&2
+  exit 1
+fi
+if ! echo "${META_JSON}" | jq -e '
+  (.data.accounts | length == 2)
+  and (.data.accounts[0].account_index == "2")
+  and (.data.accounts[1].account_index == "3")
+  and (.data.accounts[0].address != null)
+  and (.data.accounts[1].address != null)
+  and (.data.accounts[0].derivation_path != null)
+  and (.data.accounts[1].derivation_path != null)
+' >/dev/null; then
+  echo "error: range-read start=2 end=3 response mismatch" >&2
+  echo "${META_JSON}" | jq . >&2
+  exit 1
+fi
+echo "  range-read: 2 accounts (index 2..3)"
+echo "  index 2 address: $(echo "${META_JSON}" | jq -r '.data.accounts[0].address // empty')"
+echo "  index 3 address: $(echo "${META_JSON}" | jq -r '.data.accounts[1].address // empty')"
 
 echo "== batch derive reject count > 10000 (expect vault write failure) =="
 set +e

--- a/scripts/e2e_smoke.sh
+++ b/scripts/e2e_smoke.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 # End-to-end checks against a live Vault with blockchain/ mounted.
-# Covers: wallet import, auto-derive first account, read derived, list wallets/accounts, sign,
-# sign-tx/legacy + sign-tx/eip1559, sign-eip712, ECIES encrypt/decrypt roundtrip.
+# Covers: wallet import, auto-derive first account, batch derive (accounts/batch), read derived,
+# list wallets/accounts, sign, sign-tx/legacy + sign-tx/eip1559, sign-eip712, ECIES encrypt/decrypt
+# roundtrip.
 # Uses a fixed BIP-39 test vector so the derived address is deterministic.
 #
 # There is no standalone read/write on blockchain/wallets/:wallet_id (touch was removed); use LIST
 # wallets/ or derived account paths instead.
 #
 # New derived accounts are created with vault write -force on .../wallets/:id/accounts/ (server picks
-# the next index). Per-index paths .../accounts/:index/{sign,sign-tx,...} still register Create and
+# the next index), or vault write .../wallets/:id/accounts/batch count=N (up to 10000 per request).
+# Per-index paths .../accounts/:index/{sign,sign-tx,...} still register Create and
 # Update with the same handler so Vault can route HTTP writes after ExistenceCheck (usually Update).
 #
 # If vault read returns 405 unsupported operation after you rebuild the plugin, the mount may
@@ -59,6 +61,7 @@ EIP712_PRIMARY_TYPE="Person"
 EIP712_PAYLOAD='{"types":{"EIP712Domain":[{"name":"name","type":"string"}],"Person":[{"name":"name","type":"string"}]},"primaryType":"Person","domain":{"name":"Test Domain"},"message":{"name":"Cow"}}'
 
 wallet_accounts_root="blockchain/wallets/${E2E_WALLET}/accounts/"
+wallet_accounts_batch="blockchain/wallets/${E2E_WALLET}/accounts/batch"
 acct_base="blockchain/wallets/${E2E_WALLET}/accounts/0"
 single_base="blockchain/accounts/${E2E_ACCOUNT}"
 
@@ -124,6 +127,62 @@ vault list blockchain/wallets/
 
 echo "== list accounts for wallet =="
 vault list "blockchain/wallets/${E2E_WALLET}/accounts/" || echo "(no list entries; if you just rebuilt the plugin, run make setup-plugin-local to reload)"
+
+echo "== batch derive 3 accounts (indices 1,2,3 after index 0) =="
+BATCH_JSON="$(vault_write_json "${wallet_accounts_batch}" count=3)"
+BATCH_WID="$(require_jq "${BATCH_JSON}" '.data.wallet_id // empty' 'expected .data.wallet_id from batch derive')"
+if [[ "${BATCH_WID}" != "${E2E_WALLET}" ]]; then
+  echo "error: batch wallet_id mismatch: got ${BATCH_WID} want ${E2E_WALLET}" >&2
+  exit 1
+fi
+BATCH_LEN="$(echo "${BATCH_JSON}" | jq '.data.accounts | length')"
+if [[ "${BATCH_LEN}" != "3" ]]; then
+  echo "error: expected 3 accounts in batch response, got ${BATCH_LEN}" >&2
+  echo "${BATCH_JSON}" | jq . >&2
+  exit 1
+fi
+if ! echo "${BATCH_JSON}" | jq -e '
+  (.data.accounts | length == 3)
+  and (.data.accounts[0].account_index == "1")
+  and (.data.accounts[1].account_index == "2")
+  and (.data.accounts[2].account_index == "3")
+  and (.data.accounts[0].address != null)
+  and (.data.accounts[0].derivation_path != null)
+' >/dev/null; then
+  echo "error: batch accounts shape or indices mismatch" >&2
+  echo "${BATCH_JSON}" | jq . >&2
+  exit 1
+fi
+echo "  batch: 3 accounts (index 1..3)"
+
+echo "== list accounts after batch (expect keys 0..3) =="
+LIST_ACCTS_JSON="$(vault list -format=json "blockchain/wallets/${E2E_WALLET}/accounts/")"
+if ! echo "${LIST_ACCTS_JSON}" | jq -e '
+  (if type == "array" then . elif (has("data") and (.data | type == "object") and (.data | has("keys"))) then .data.keys else [] end)
+  | (sort == ["0","1","2","3"])
+' >/dev/null; then
+  echo "error: expected list keys [0,1,2,3] after batch" >&2
+  echo "${LIST_ACCTS_JSON}" | jq . >&2
+  exit 1
+fi
+echo "  list keys OK"
+
+echo "== batch derive reject count > 10000 (expect vault write failure) =="
+set +e
+BAD_OUT="$(vault write -format=json "${wallet_accounts_batch}" count=10001 2>&1)"
+BAD_RC=$?
+set -e
+if [[ "${BAD_RC}" -eq 0 ]]; then
+  echo "error: expected vault write to fail for count=10001" >&2
+  echo "${BAD_OUT}" >&2
+  exit 1
+fi
+if ! echo "${BAD_OUT}" | tr '[:upper:]' '[:lower:]' | grep -Fq '10000'; then
+  echo "error: expected error output to mention 10000 limit" >&2
+  echo "${BAD_OUT}" >&2
+  exit 1
+fi
+echo "  rejected as expected"
 
 echo "== sign (keccak + ecdsa) =="
 SIGN_JSON="$(vault_write_json "${acct_base}/sign" data="${PLAINTEXT_HEX}")"


### PR DESCRIPTION
## Overview

A series of improvements to the HD wallet derived account lifecycle: atomic
per-wallet counter allocation, batch account creation, and a cleaner range-read
API that removes the `/metadata` suffix in favour of query params on the
collection endpoint.

## Breaking Changes

- `GET` / `POST` `blockchain/wallets/:wallet_id/accounts/metadata` is removed;
  range read is now `GET blockchain/wallets/:wallet_id/accounts?start=N&end=M`

## New Features

### Per-wallet atomic counter (`feat: implement per-wallet mutex`)

- `ethereumBackend` now holds a `sync.Map` of per-wallet `sync.Mutex` locks
- Counter read-increment-write is fully serialised within the active Vault node,
  preventing duplicate index assignment under concurrent requests

### Batch account creation (`feat: add batch derived accounts`)

- `POST blockchain/wallets/:wallet_id/accounts/batch` — create 1–10 000
  accounts in a single request
- Upfront BIP-44 overflow check rejects the entire batch before any write;
  partial-write on storage error is self-healing via deterministic BIP-44 derivation

### Range read on collection endpoint (`refactor!: replace accounts/metadata`)

- `GET blockchain/wallets/:wallet_id/accounts?start=N&end=M` replaces the
  dedicated `/metadata` path (same behaviour: both params required, span ≤ 10 000,
  all indices must exist in storage)
- Extracted `parseInclusiveIndexRange` helper to centralise the validation logic
- `LIST .../accounts/` is unchanged — returns all stored index keys, no range filter

## Bug Fixes

- `fix: cap list-derived start/end at MaxBIP44AddressIndex` — `start`/`end`
  values beyond `2147483647` now return a clear validation error

## Testing

- `test: add partial-write self-heal and UpdateOperation coverage` — verifies
  the retry-at-same-index behaviour when `WriteWalletCounter` fails mid-write
- `TestHandleReadDerivedAccountsRange_*` replaces metadata test suite; adds
  `_missingStart` and `_missingEnd` cases for Method A validation
- `TestPaths_listDerivedAccounts_registersRead` asserts `accounts/?` carries
  `ReadOperation` alongside `List`, `Create`, `Update`



